### PR TITLE
Fix sonarcloud connectivity

### DIFF
--- a/sonarqube-ant-task/pom.xml
+++ b/sonarqube-ant-task/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.sonarsource.scanner.api</groupId>
       <artifactId>sonar-scanner-api</artifactId>
-      <version>2.8</version>
+      <version>2.9.0.887</version>
     </dependency>
     <!-- Would be provided by environment -->
     <dependency>

--- a/sonarqube-ant-task/src/main/java/org/sonarsource/scanner/ant/SonarQubeTask.java
+++ b/sonarqube-ant-task/src/main/java/org/sonarsource/scanner/ant/SonarQubeTask.java
@@ -98,7 +98,11 @@ public class SonarQubeTask extends Task {
       }
       runner.runAnalysis(properties);
     } finally {
-      runner.stop();
+      try {
+        runner.stop();
+      } catch (Exception e) {
+        log("Could not stop runner", e, Project.MSG_WARN);
+      }
     }
   }
 


### PR DESCRIPTION
Resolve an issue with trying to use the Ant Sonar task against SonarCloud, plus an associated exception handling problem that masked this initial issue. No tests are provided for these changes given the structure of the code does not provide any way to mock the necessary method calls, and refactoring the code-base to support such calls would have been a far more intrusive change.

The latest version of `sonar-scanner-api` was not used here since `sonar-scanner-api` changed significantly in 2.10 which would have required a significant re-write of `SonarQubeTask` to accommodate.