### PR TITLE
ANTTASK-61 Update QA to next LTS (7.9) + ANTTASK-62 Upgrade test profiles for SonarJava 6

### DIFF
--- a/.cix.yml
+++ b/.cix.yml
@@ -4,7 +4,7 @@
 
 SQ_VERSION: 
   - DEV
-  - LATEST_RELEASE[6.7]
+  - LATEST_RELEASE[7.9]
 
 SLAVE:
   - linux

--- a/its/src/test/java/org/sonarsource/scanner/ant/it/AntTest.java
+++ b/its/src/test/java/org/sonarsource/scanner/ant/it/AntTest.java
@@ -111,8 +111,8 @@ public class AntTest {
       .getIssuesList();
 
     assertThat(issues.size()).isEqualTo(2);
-    assertThat(containsRule("squid:CallToDeprecatedMethod", issues)).isTrue();
-    assertThat(containsRule("squid:S1147", issues)).isTrue();
+    assertThat(containsRule("java:S1874", issues)).isTrue();
+    assertThat(containsRule("java:S1147", issues)).isTrue();
   }
 
   /**
@@ -132,7 +132,7 @@ public class AntTest {
       .setComponentKeys(Collections.singletonList(projectKey)))
       .getIssuesList();
     assertThat(issues.size()).isEqualTo(1);
-    assertThat(issues.get(0).getRule()).isEqualTo("squid:CallToDeprecatedMethod");
+    assertThat(issues.get(0).getRule()).isEqualTo("java:S1874");
   }
 
   @Test

--- a/its/src/test/java/org/sonarsource/scanner/ant/it/AntTest.java
+++ b/its/src/test/java/org/sonarsource/scanner/ant/it/AntTest.java
@@ -59,7 +59,7 @@ public class AntTest {
 
   @ClassRule
   public static final Orchestrator orchestrator = Orchestrator.builderEnv()
-    .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE[6.7]"))
+    .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE[7.9]"))
     .addPlugin(MavenLocation.of("org.sonarsource.java", "sonar-java-plugin", "LATEST_RELEASE"))
     .restoreProfileAtStartup(FileLocation.ofClasspath("/com/sonar/ant/it/profile-java-empty.xml"))
     .restoreProfileAtStartup(FileLocation.ofClasspath("/com/sonar/ant/it/profile-java-classpath.xml"))

--- a/its/src/test/resources/com/sonar/ant/it/profile-java-classpath.xml
+++ b/its/src/test/resources/com/sonar/ant/it/profile-java-classpath.xml
@@ -4,17 +4,17 @@
   <language>java</language>
   <rules>
     <rule>
-      <repositoryKey>squid</repositoryKey>
-      <key>CallToDeprecatedMethod</key>
+      <repositoryKey>java</repositoryKey>
+      <key>S1874</key>
       <priority>MINOR</priority>
     </rule>
     <rule>
-      <repositoryKey>squid</repositoryKey>
+      <repositoryKey>java</repositoryKey>
       <key>S1147</key>
       <priority>BLOCKER</priority>
     </rule>
     <rule>
-      <repositoryKey>squid</repositoryKey>
+      <repositoryKey>java</repositoryKey>
       <key>S1845</key>
       <priority>MAJOR</priority>
     </rule>


### PR DESCRIPTION
The release of SonarJava 6 breaks our QA:

- SonarJava 6 is not compatible with 6.7 LTS. Upgrade QA to run against 7.9.
- SonarJava 6 deprecates the `squid` repository key, which was still in use (see [SONARJAVA-3160](https://jira.sonarsource.com/browse/SONARJAVA-3160)).
  - Update our QA profiles to use the new `java` key instead.
  - Update our QA profile to use the new `S1874` rule instead of `CallToDeprecatedMethod`.

See [Jenkins job 1327](https://cix.sonarsource.com/job/sonar-scanner-ant-qa/1327/) for QA status of this PR (not reported in GH checks...)