### PR TITLE
ANTTASK-66 Update license headers for 2023

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ env:
 # RE-USABLE CONFIGS
 #
 container_definition: &CONTAINER_DEFINITION
-  image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j11-m3-latest
+  image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-m3-latest
   cluster_name: ${CIRRUS_CLUSTER_NAME}
   region: eu-central-1
   namespace: default

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 SonarQube Scanner for Ant
-Copyright (C) 2011-2017 SonarSource SA
+Copyright (C) 2011-2023 SonarSource SA
 mailto:info AT sonarsource DOT com
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ Make sure that you follow our [code style](https://github.com/SonarSource/sonar-
 License
 -------
 
-Copyright 2011-2022 SonarSource.
+Copyright 2011-2023 SonarSource.
 
 Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt))

--- a/its/docker/Dockerfile
+++ b/its/docker/Dockerfile
@@ -12,7 +12,7 @@
 #------------------------------------------------------------------------------
 
 ARG CIRRUS_AWS_ACCOUNT=275878209202
-FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j11-m3-latest
+FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-m3-latest
 
 ARG ANT_VERSION=1.10.12
 

--- a/its/projects/java-without-bytecode/build.xml
+++ b/its/projects/java-without-bytecode/build.xml
@@ -20,7 +20,7 @@
   </target>
 
   <target name="compile" depends="init">
-    <javac srcdir="${src.dir}" destdir="${classes.dir}" source="6" target="6" classpathref="classpath" fork="true" debug="true" includeAntRuntime="false" />
+    <javac srcdir="${src.dir}" destdir="${classes.dir}" source="7" target="7" classpathref="classpath" fork="true" debug="true" includeAntRuntime="false" />
   </target>
 
   <!-- Define Sonar Properties -->

--- a/its/projects/project-key-without-groupId/build.xml
+++ b/its/projects/project-key-without-groupId/build.xml
@@ -15,7 +15,7 @@
   </target>
 
   <target name="compile" depends="init">
-    <javac srcdir="${src.dir}" destdir="${classes.dir}" source="6" target="6" fork="true" debug="true" includeAntRuntime="false" />
+    <javac srcdir="${src.dir}" destdir="${classes.dir}" source="7" target="7" fork="true" debug="true" includeAntRuntime="false" />
   </target>
 
   <!-- Define Sonar Properties -->

--- a/its/projects/project-metadata/build.xml
+++ b/its/projects/project-metadata/build.xml
@@ -21,7 +21,7 @@
   </target>
 
   <target name="compile" depends="init">
-    <javac srcdir="${src.dir}" destdir="${classes.dir}" source="6" target="6" classpathref="classpath" fork="true" debug="true" includeAntRuntime="false" />
+    <javac srcdir="${src.dir}" destdir="${classes.dir}" source="7" target="7" classpathref="classpath" fork="true" debug="true" includeAntRuntime="false" />
   </target>
 
   <!-- Define Sonar Properties -->

--- a/its/projects/shared/build.xml
+++ b/its/projects/shared/build.xml
@@ -21,7 +21,7 @@
   </target>
 
   <target name="compile" depends="init">
-    <javac srcdir="${src.dir}" destdir="${classes.dir}" source="6" target="6" classpathref="classpath" fork="true" debug="true" includeAntRuntime="false" />
+    <javac srcdir="${src.dir}" destdir="${classes.dir}" source="7" target="7" classpathref="classpath" fork="true" debug="true" includeAntRuntime="false" />
   </target>
 
   <!-- Define Sonar Properties -->

--- a/its/src/test/java/org/sonarsource/scanner/ant/it/AntTest.java
+++ b/its/src/test/java/org/sonarsource/scanner/ant/it/AntTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: IT :: Ant task
- * Copyright (C) 2009-2022 SonarSource SA
+ * Copyright (C) 2009-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>61.0.147</version>
+    <version>65.0.218</version>
     <relativePath />
   </parent>
 

--- a/sonarqube-ant-task/src/main/java/org/sonarsource/scanner/ant/SonarQubeTask.java
+++ b/sonarqube-ant-task/src/main/java/org/sonarsource/scanner/ant/SonarQubeTask.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Ant
- * Copyright (C) 2011-2022 SonarSource SA
+ * Copyright (C) 2011-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonarqube-ant-task/src/main/java/org/sonarsource/scanner/ant/SonarQubeTaskUtils.java
+++ b/sonarqube-ant-task/src/main/java/org/sonarsource/scanner/ant/SonarQubeTaskUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Ant
- * Copyright (C) 2011-2022 SonarSource SA
+ * Copyright (C) 2011-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonarqube-ant-task/src/main/java/org/sonarsource/scanner/ant/package-info.java
+++ b/sonarqube-ant-task/src/main/java/org/sonarsource/scanner/ant/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Ant
- * Copyright (C) 2011-2022 SonarSource SA
+ * Copyright (C) 2011-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonarqube-ant-task/src/test/java/org/sonarsource/scanner/ant/SonarQubeTaskTest.java
+++ b/sonarqube-ant-task/src/test/java/org/sonarsource/scanner/ant/SonarQubeTaskTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Ant
- * Copyright (C) 2011-2022 SonarSource SA
+ * Copyright (C) 2011-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonarqube-ant-task/src/test/java/org/sonarsource/scanner/ant/SonarQubeTaskUtilsTest.java
+++ b/sonarqube-ant-task/src/test/java/org/sonarsource/scanner/ant/SonarQubeTaskUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Ant
- * Copyright (C) 2011-2022 SonarSource SA
+ * Copyright (C) 2011-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or


### PR DESCRIPTION
Note: I had to update the QA to be compatible with Java 17, since we dropped support for Java 11 in SonarQube 9.9.