### PR TITLE
Deprecate SonarScanner for Ant

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,7 +105,7 @@ qa_task:
     memory: 5Gb
   env:
     matrix:
-      - SQ_VERSION: LATEST_RELEASE[8.9]
+      - SQ_VERSION: LATEST_RELEASE[9.9]
       - SQ_VERSION: DEV
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 SonarQube Scanner for Ant
 =========================
-[![Build Status](https://api.cirrus-ci.com/github/SonarSource/sonar-scanner-ant.svg)](https://cirrus-ci.com/github/SonarSource/sonar-scanner-ant)
 
-Documentation:
+# Deprecated
+
+> :warning: SonarQube Scanner for Ant is deprecated. You should use the [SonarScanner CLI](https://github.com/SonarSource/sonar-scanner-cli) instead.
+
+This repository is no longer maintained and has been deprecated.
+
+# Documentation
 http://redirect.sonarsource.com/doc/ant-task.html
 
 Have Question or Feedback?

--- a/its/src/test/java/org/sonarsource/scanner/ant/it/AntTest.java
+++ b/its/src/test/java/org/sonarsource/scanner/ant/it/AntTest.java
@@ -59,7 +59,7 @@ public class AntTest {
 
   @ClassRule
   public static final Orchestrator orchestrator = Orchestrator.builderEnv()
-    .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE[8.9]"))
+    .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE[9.9]"))
     .useDefaultAdminCredentialsForBuilds(true)
     .addBundledPlugin(MavenLocation.of("org.sonarsource.java", "sonar-java-plugin", "LATEST_RELEASE"))
     .restoreProfileAtStartup(FileLocation.ofClasspath("/com/sonar/ant/it/profile-java-empty.xml"))


### PR DESCRIPTION
Add a message to inform that the SonarScanner for Ant is deprecated and the SonarScanner CLI should be used instead.