### PR TITLE
ANTTASK-71 using the version of cyclonex plugin that doesn't throw errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>65.0.218</version>
+    <version>70.0.0.270</version>
     <relativePath />
   </parent>
 
@@ -72,7 +72,6 @@
             </goals>
           </execution>
         </executions>
-        <version>2.7.10</version>
       </plugin>
     </plugins>
   </build>	

--- a/pom.xml
+++ b/pom.xml
@@ -28,29 +28,6 @@
     </license>
   </licenses>
 
-  <developers>
-    <developer>
-      <id>godin</id>
-      <name>Evgeny Mandrikov</name>
-      <timezone>+3</timezone>
-    </developer>
-    <developer>
-      <id>simon.brandhof</id>
-      <name>Simon Brandhof</name>
-      <timezone>+1</timezone>
-    </developer>
-    <developer>
-      <id>bellingard</id>
-      <name>Fabrice Bellingard</name>
-      <timezone>+1</timezone>
-    </developer>
-    <developer>
-      <id>henryju</id>
-      <name>Julien Henry</name>
-      <timezone>+1</timezone>
-    </developer>
-  </developers>
-
   <modules>
     <module>sonarqube-ant-task</module>
   </modules>
@@ -95,6 +72,7 @@
             </goals>
           </execution>
         </executions>
+        <version>2.7.10</version>
       </plugin>
     </plugins>
   </build>	


### PR DESCRIPTION
This fixes the first issue described in the ticket. The second one was caused by redeployment of Next so I moved the cron job to 3 am to be safe.

I spoke with @henryju and it doesn't make sense anymore to keep the list of developers in the pom.xml so I cleaned it up.