### PR TITLE
BUILD-5727 Update Cirrus CI image used to use JDK21 LTS instead of JDK18 EOL)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,7 +64,7 @@ mend_scan_task:
   # run only on master and long-living branches
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "mend-.*")
   eks_container:
-    image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j18-latest
+    image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j21-latest
     region: eu-central-1
     cluster_name: ${CIRRUS_CLUSTER_NAME}
     namespace: default


### PR DESCRIPTION
## Changes

- [x] Cirrus CI use JDK21 LTS instead of JDK18 EOL for mend_scan_task
      That way the CI keep working (ci-docker-images will no longer build EOL versions of JDK)